### PR TITLE
Update drag-ruler.js

### DIFF
--- a/module/system/drag-ruler.js
+++ b/module/system/drag-ruler.js
@@ -8,10 +8,10 @@ export const onDragRulerReady = (SpeedProvider) => {
     }
 
     getRanges(token) {
-      const speed = token.actor.attributes?.speed?.max ?? 6;
+      const speed = token.actor.attributes?.speed?.max ?? 0.6;
       return [
         { range: 0, color: "stay" },
-        { range: speed * 5, color: "walk" },
+        { range: speed * 50, color: "walk" },
       ];
     }
   }


### PR DESCRIPTION
Changed default speed to 0.6 and the range multiplier to 50 so that drag ruler works with both individual scale NPCs and PCs with default speed of 30' and naval scale actors where speed indicates the number of 50' hexes they can travel.