### PR TITLE
v0.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.6.10
+
+- Fix ships incorrectly ignoring armor when attacking other ships.
+  - They now list the target ship's armor in the attack dialog without you needing to re-target the ship.
+
 # v0.6.9
 
 - System chat message cards should now display in the selected chat message mode (public, private etc.).

--- a/module/dialog/crew-action-dialog.js
+++ b/module/dialog/crew-action-dialog.js
@@ -28,10 +28,6 @@ class CrewActionDialog extends Application {
     this.enableArmorSelection = enableArmorSelection;
     this.enableMovementSelection = enableMovementSelection;
     this.enableTargetSelection = enableTargetSelection;
-    this.enforceTargetSelection = isEnforceTargetEnabled();
-    this.shouldIgnoreArmor = this._shouldIgnoreArmor();
-    this.buttonLabel = buttonLabel;
-    this.callback = callback;
 
     if (this.enableTargetSelection) {
       this.isTargetSelectionValid = isTargetSelectionValid();
@@ -39,6 +35,11 @@ class CrewActionDialog extends Application {
       this.targetToken = findTargettedToken();
       this._ontargetChangedHook = registerTargetAutomationHook(this._onTargetChanged.bind(this));
     }
+
+    this.enforceTargetSelection = isEnforceTargetEnabled();
+    this.shouldIgnoreArmor = this._shouldIgnoreArmor();
+    this.buttonLabel = buttonLabel;
+    this.callback = callback;
   }
 
   /** @override */

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "pirateborg",
   "title": "PIRATE BORG",
   "description": "Foundry VTT system for PIRATE BORG.",
-  "version": "v0.6.9",
+  "version": "v0.6.10",
   "compatibility": {
     "minimum": "10",
     "verified": "11"


### PR DESCRIPTION
- Fix ships incorrectly ignoring armor when attacking other ships.
  - They now list the target ship's armor in the attack dialog without you needing to re-target the ship.