### PR TITLE
v0.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.6.11
+
+- Fix Zealot's rolled from The Tavern incorrectly having `1d4 + spirit` prayers, instead of the correct `1d2 + spirit` (thanks 525600Mimics).
+
 # v0.6.10
 
 - Fix ships incorrectly ignoring armor when attacking other ships.

--- a/module/api/generator/character-generator.js
+++ b/module/api/generator/character-generator.js
@@ -374,7 +374,7 @@ export const rollCharacterForClass = async (cls) => {
   const description = generateDescription(cls, baseTables);
 
   const powerUsesRoll = Math.max(0, (await evaluateFormula(`1d4 + ${abilities.spirit}`)).total);
-  const extraResourceRoll = Math.max(0, (await evaluateFormula(`1d4 + ${abilities.spirit}`)).total);
+  const extraResourceRoll = Math.max(0, (await evaluateFormula(cls.system.extraResourceFormula.replace("@abilities.spirit.value", abilities.spirit))).total);
 
   const allDocs = [
     ...baseTables,

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "pirateborg",
   "title": "PIRATE BORG",
   "description": "Foundry VTT system for PIRATE BORG.",
-  "version": "v0.6.10",
+  "version": "v0.6.11",
   "compatibility": {
     "minimum": "10",
     "verified": "11"


### PR DESCRIPTION
- Fix Zealot's rolled from The Tavern incorrectly having `1d4 + spirit` prayers, instead of the correct `1d2 + spirit` (thanks 525600Mimics).