### PR TITLE
v0.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.6.12
+
+- Fix classes that don't have any extra resources from failing to generate in the Tavern.
+  - Bug was introduced in v0.6.11
+- Naval NPCs now correctly show their movement speed in the drag ruler (thanks 525600Mimics).
+
 # v0.6.11
 
 - Fix Zealot's rolled from The Tavern incorrectly having `1d4 + spirit` prayers, instead of the correct `1d2 + spirit` (thanks 525600Mimics).

--- a/module/api/generator/character-generator.js
+++ b/module/api/generator/character-generator.js
@@ -374,7 +374,8 @@ export const rollCharacterForClass = async (cls) => {
   const description = generateDescription(cls, baseTables);
 
   const powerUsesRoll = Math.max(0, (await evaluateFormula(`1d4 + ${abilities.spirit}`)).total);
-  const extraResourceRoll = Math.max(0, (await evaluateFormula(cls.system.extraResourceFormula.replace("@abilities.spirit.value", abilities.spirit))).total);
+  const extraResourceFormula = (cls.system.extraResourceFormula || "0").replace("@abilities.spirit.value", abilities.spirit);
+  const extraResourceRoll = Math.max(0, (await evaluateFormula(extraResourceFormula)).total);
 
   const allDocs = [
     ...baseTables,

--- a/module/system/drag-ruler.js
+++ b/module/system/drag-ruler.js
@@ -11,7 +11,7 @@ export const onDragRulerReady = (SpeedProvider) => {
       // Most creatures can travel 30' (or six 5-foot squares) a round.
       // Ships play on a 50' hex grid and can move their speed in hexes.
       const speed = token.actor.attributes?.speed?.max ?? 6;
-      const gridScale = (token.actor.type === 'vehicle') ? 50 : 5;
+      const gridScale = (['vehicle', 'vehicle_npc'].includes(token.actor.type)) ? 50 : 5;
       return [
         { range: 0, color: "stay" },
         { range: speed * gridScale, color: "move" },

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "pirateborg",
   "title": "PIRATE BORG",
   "description": "Foundry VTT system for PIRATE BORG.",
-  "version": "v0.6.11",
+  "version": "v0.6.12",
   "compatibility": {
     "minimum": "10",
     "verified": "11"


### PR DESCRIPTION
- Fix classes that don't have any extra resources from failing to generate in the Tavern.
  - Bug was introduced in v0.6.11
- Naval NPCs now correctly show their movement speed in the drag ruler (thanks 525600Mimics).