### PR TITLE
v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.0.1
+
+- Allow actors to Long Rest without requiring their token to be on the canvas.
+- Fix display of ship type on the ship edit sheet.
+- Fix ammo not being consumed when using v11.
+  - Bug was introduced as part of v12 compatibility.
+
 # v1.0.0
 
 - Foundry VTT v12 compatibility.

--- a/module/api/automation/outcome-damage.js
+++ b/module/api/automation/outcome-damage.js
@@ -13,13 +13,19 @@ export const DAMAGE_TYPE = {
  * @return {Promise<void>}
  */
 export const applyOnToken = async (outcome, tokenId, fn) => {
-  if (!tokenId) return;
+  if (!tokenId && !outcome.initiatorActor) return;
+  let actor;
   const token = canvas.tokens.get(tokenId);
-  const isValid = token && token?.actor && isAutomaticDamageEnabled();
+  if (token?.actor) {
+    actor = token.actor;
+  } else if (outcome.initiatorActor) {
+    actor = game.actors.get(outcome.initiatorActor);
+  }
+  const isValid = actor && isAutomaticDamageEnabled();
 
   if (!isValid) return;
 
-  await fn(outcome, token.actor);
+  await fn(outcome, actor);
 };
 
 /**

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "pirateborg",
   "title": "PIRATE BORG",
   "description": "Foundry VTT system for PIRATE BORG.",
-  "version": "v1.0.0",
+  "version": "v1.0.1",
   "compatibility": {
     "minimum": "11",
     "verified": "12"
@@ -425,7 +425,7 @@
     {
       "name": "Pirate Borg System",
       "sorting": "a",
-      "color": "#ff0000",
+      "color": "#000000",
       "packs": [
         "containers",
         "equipment-melee-weapons",

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -160,7 +160,7 @@
               <div class="ammo-select-col">                
                 <select class="ammo-select" name="selectedAmmo-{{item._id}}" data-dtype="Number" data-item-id="{{item._id}}">
                   <option value="">{{localize 'PB.SelectAmmo'}}</option>
-                  {{selectOptions ../data.system.dynamic.ammo selected=item.system.ammoId valueAttr="_id" labelAttr="fullName"}}
+                  {{selectOptions ../data.system.dynamic.ammo selected=item.system.ammoId nameAttr="_id" valueAttr="_id" labelAttr="fullName"}}
                 </select>
               </div>
               {{/if}} {{/if}}

--- a/templates/actor/vehicle-edit-sheet.html
+++ b/templates/actor/vehicle-edit-sheet.html
@@ -9,7 +9,7 @@
         <input class="actor-name container-name" name="name" type="text" value="{{data.name}}" placeholder="{{ localize 'PB.Name' }}" />
       </div>
       <div class="header-subtitle-row">
-        <div class="actor-type">{{data.localizedType}}</div>
+        <div class="actor-type">{{localize data.localizedType}}</div>
       </div>
     </div>
   </header>


### PR DESCRIPTION
- Allow actors to Long Rest without requiring their token to be on the canvas.
- Fix display of ship type on the ship edit sheet.
- Fix ammo not being consumed when using v11.
  - Bug was introduced as part of v12 compatibility.