### PR TITLE
v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.4
+
+- It turns out pirates don't use ammo for melee weapons.
+  - Melee weapons will no longer complain about invalid ammo.
+
 # v1.0.3
 
 - Prompt the player when they try to reload a weapon that has run out of ammo.

--- a/module/api/action/character/character-attack-action.js
+++ b/module/api/action/character/character-attack-action.js
@@ -105,6 +105,9 @@ const isAttackValid = (weapon, ammo) => {
  * @returns {Boolean}
  */
 const isAmmoValid = (weapon, ammo) => {
+  if (!weapon.usesAmmo) {
+    return true;
+  }
   if (!ammo) {
     return false;
   }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "pirateborg",
   "title": "PIRATE BORG",
   "description": "Foundry VTT system for PIRATE BORG.",
-  "version": "v1.0.3",
+  "version": "v1.0.4",
   "compatibility": {
     "minimum": "11",
     "verified": "12"


### PR DESCRIPTION
- It turns out pirates don't use ammo for melee weapons.
  - Melee weapons will no longer complain about invalid ammo.