### PR TITLE
Refactor carrying capacity calculation to use dynamic carryingModifier

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -446,7 +446,8 @@ export class PBActor extends Actor {
    * @return {Number}
    */
   get normalCarryingCapacity() {
-    return this.abilities.strength.value + 8;
+    const carryingModifier = this.attributes?.carryingModifier?.value ?? 8;
+    return this.abilities.strength.value + carryingModifier;
   }
 
   /**

--- a/template.json
+++ b/template.json
@@ -100,6 +100,9 @@
           "min": 0,
           "max": 0,
           "value": 0
+        },
+        "carryingModifier": {
+          "value": 8
         }
       }
     },


### PR DESCRIPTION
# Carrying Capacity Effect Key
`system.attributes.carryingModifier.value`

## Overview
- The base carrying capacity is calculated as: `Strength + carryingModifier`
- The default `carryingModifier` value is 8

## Example Usage

### Increase Carrying Capacity by 2
- **Key**: `system.attributes.carryingModifier.value`
- **Mode**: Add
- **Value**: 2

### Set Carrying Capacity Modifier to 10
- **Key**: `system.attributes.carryingModifier.value`
- **Mode**: Override
- **Value**: 10
- Note, this still adds the strength mod, its better to use add vs override.

### Decrease Carrying Capacity by 3
- **Key**: `system.attributes.carryingModifier.value`
- **Mode**: Add
- **Value**: -3