### PR TITLE
v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.1.4
+
+- Added Carrying Capacity Effect Key.
+  - This allows an Active Effect to be applied to a character to adjust their carrying capacity.
+  - `system.attributes.carryingModifier.value`
+  - The default value is `8`. The character's strength value is _always_ added to this value.
+    - Thank you r2DoesInc for the contribution [#58](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/pull/58).
+    - Thank you Alexia for the suggestion on Discord.
+
 # v1.1.3
 
 - Fixed "Thing of Importance" 65 (tattoo).

--- a/module/api/generator/character-generator.js
+++ b/module/api/generator/character-generator.js
@@ -444,6 +444,9 @@ const characterToActorData = (characterData) => ({
         max: characterData.extraResourceUses,
         value: characterData.extraResourceUses,
       },
+      carryingModifier: {
+        value: characterData.carryingModifier ?? 8,
+      }
     },
     silver: characterData.silver,
     baseClass: characterData.baseClass || "",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "pirateborg",
   "title": "PIRATE BORG",
   "description": "Foundry VTT system for PIRATE BORG.",
-  "version": "v1.1.3",
+  "version": "v1.1.4",
   "compatibility": {
     "minimum": "12",
     "verified": "13"


### PR DESCRIPTION
- Added Carrying Capacity Effect Key.
  - This allows an Active Effect to be applied to a character to adjust their carrying capacity.
  - `system.attributes.carryingModifier.value`
  - The default value is `8`. The character's strength value is _always_ added to this value.
    - Thank you r2DoesInc for the contribution [#58](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/pull/58).
    - Thank you Alexia for the suggestion on Discord.