### PR TITLE
Only include a class' flavour text if it exists

### DIFF
--- a/module/api/generator/character-generator.js
+++ b/module/api/generator/character-generator.js
@@ -349,7 +349,8 @@ export const generateDescription = (cls, items) => {
     ])
     .join("...");
 
-  return `<p>${cls.flavorText}</p><p>${description}</p>`;
+  const flavorText = cls.flavorText ? `<p>${cls.flavorText}</p>` : "";
+  return `${flavorText}<p>${description}</p>`;
 };
 
 /**


### PR DESCRIPTION
- Custom classes that do not include a flavor text will no longer add an empty line to the start of the character's History text.