### PR TITLE
Move "Cancel" button to the right hand side on "Gain Experience" dialog.

### DIFF
--- a/module/actor/sheet/character-sheet.js
+++ b/module/actor/sheet/character-sheet.js
@@ -397,9 +397,6 @@ export class PBActorSheetCharacter extends PBActorSheet {
         title: game.i18n.localize("PB.GetBetter"),
         content: game.i18n.localize("PB.GetBetterConfirmMessage"),
         buttons: {
-          cancel: {
-            label: game.i18n.localize("PB.Cancel"),
-          },
           getbetter: {
             icon: '<i class="fas fa-check"></i>',
             label: game.i18n.localize("PB.GetBetter"),
@@ -411,6 +408,9 @@ export class PBActorSheetCharacter extends PBActorSheet {
 
               return characterGetBetterAction(this.actor);
             },
+          },
+          cancel: {
+            label: game.i18n.localize("PB.Cancel"),
           },
         },
         default: "cancel",


### PR DESCRIPTION
- When a character gains experience, the dialog shown to the player now has the "Cancel" button on the right hand side to better align with other dialogs throughout Foundry VTT.

<img width="444" height="200" alt="image" src="https://github.com/user-attachments/assets/bba7a2c8-8e60-42fa-adcb-31922687e44d" />
