### PR TITLE
Invalid item references no longer adds undefined to the results

### DIFF
--- a/module/api/compendium.js
+++ b/module/api/compendium.js
@@ -105,7 +105,10 @@ export const findItemsFromCompendiumString = async (compendiumString) => {
   const results = [];
   for (const compendiumsItem of compendiumsItems) {
     const [compendium, table] = compendiumInfoFromString(compendiumsItem);
-    results.push(await findCompendiumItem(compendium, table));
+    const item = await findCompendiumItem(compendium, table);
+    if (item) {
+      results.push(item);
+    }
   }
   return results;
 };


### PR DESCRIPTION
Changelog:

- Incorrectly configured classes or references will no longer break character generation if the Tavern cannot find a matching item.