### PR TITLE
Add PR validation workflow

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 node_modules/
 tasks/
+REFERENCE/
 commitlint.config.js
 lint-staged.config.js
 .releaserc.js

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,57 @@
+name: PR checks
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-pr-title:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Validate conventional-commit PR title
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Types must match the release rules in .releaserc.js. Hidden types (chore, refactor, etc.)
+          # are still allowed so non-release work can land; only feat/fix/perf/build(deps) trigger version bumps.
+          types: |
+            feat
+            fix
+            perf
+            docs
+            ci
+            build
+            chore
+            refactor
+            test
+            style
+            revert
+          requireScope: false
+
+  validate:
+    name: Lint and format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prettier check + ESLint
+        run: npm run validate

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 css/
 packs/_source/
 node_modules
+REFERENCE/
 *.min.css
 *.min.js
 *.html

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ css/
 packs/_source/
 node_modules
 REFERENCE/
+system.json
 *.min.css
 *.min.js
 *.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,13 @@
 # [1.5.0](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/compare/v1.4.0...v1.5.0) (2026-05-23)
 
-
 ### Bug Fixes
 
-* **chat:** translate legacy rollMode values ([b67219c](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/commit/b67219cfeb3cebef652fc05f4da1c02997f9f2cf))
-
+- **chat:** translate legacy rollMode values ([b67219c](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/commit/b67219cfeb3cebef652fc05f4da1c02997f9f2cf))
 
 ### Features
 
-* **vehicle-sheet:** add tab navigation for combat and effects ([6828e33](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/commit/6828e33d0e0fe5c42524a5954fe0d28f28f14e56))
-* **vehicle-sheet:** implement vehicle sheet styling and layout ([8fa7e4b](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/commit/8fa7e4bec37d98a6c4faa06628480914be189989))
+- **vehicle-sheet:** add tab navigation for combat and effects ([6828e33](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/commit/6828e33d0e0fe5c42524a5954fe0d28f28f14e56))
+- **vehicle-sheet:** implement vehicle sheet styling and layout ([8fa7e4b](https://github.com/Limithron-Foundry-VTT/pirate-borg-system/commit/8fa7e4bec37d98a6c4faa06628480914be189989))
 
 # The changelog has moved.
 

--- a/utils/foundry-remote.mjs
+++ b/utils/foundry-remote.mjs
@@ -140,17 +140,7 @@ async function runInstallDev(dryRun) {
     destination: buildRemoteDestination(config.foundryRemoteSsh, remoteSystemPath),
     dryRun,
     deleteMode: true,
-    excludes: [
-      ".git/",
-      ".github/",
-      ".cursor/",
-      ".idea/",
-      ".vscode/",
-      "node_modules/",
-      ".env",
-      "system.zip",
-      ".foundry-backups/",
-    ],
+    excludes: [".git/", ".github/", ".cursor/", ".idea/", ".vscode/", "node_modules/", ".env", "system.zip", ".foundry-backups/"],
   });
 
   console.log(`\x1b[32m✓\x1b[0m Dev install ${dryRun ? "preview complete" : "complete"}.`);


### PR DESCRIPTION
- Lint PR titles against convential commit types.
- Ignore `./REFERENCE/` locations, as those are core Foundry VTT sources.
