### PR TITLE
Align release-notes output with manual style and migrate to Releases page

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -24,25 +24,54 @@ module.exports = {
         preset: "angular",
         presetConfig: {
           types: [
-            { type: "feat", section: "Features" },
+            { type: "feat", section: "New Features" },
             { type: "fix", section: "Bug Fixes" },
             { type: "perf", section: "Performance Improvements" },
             { type: "revert", section: "Reverts" },
             { type: "docs", section: "Documentation" },
+            { type: "ci", section: "Developer Tooling" },
+            { type: "build", section: "Developer Tooling" },
             { type: "style", hidden: true },
             { type: "chore", hidden: true },
             { type: "refactor", hidden: true },
             { type: "test", hidden: true },
             { type: "build", hidden: true },
-            { type: "ci", section: "Continuous Integration" },
+            { type: "ci", hidden: true },
           ],
         },
-      },
-    ],
-    [
-      "@semantic-release/changelog",
-      {
-        changelogFile: "CHANGELOG.md",
+        writerOpts: {
+          commitGroupsSort: (a, b) => {
+            const order = ["New Features", "Bug Fixes", "Performance Improvements", "Documentation", "Reverts", "Developer Tooling"];
+            const ai = order.indexOf(a.title);
+            const bi = order.indexOf(b.title);
+            return (ai === -1 ? order.length : ai) - (bi === -1 ? order.length : bi);
+          },
+          commitsSort: ["scope", "subject"],
+          // Custom mainTemplate to produce the "## What's Changed" header, --- between sections, and a Full Changelog footer
+          // (the angular preset's default emits "# [version](compare) (date)" which is redundant on the GitHub Releases page).
+          mainTemplate: [
+            "## What's Changed",
+            "",
+            "{{#each commitGroups}}{{#unless @first}}---",
+            "",
+            "{{/unless}}### {{title}}",
+            "",
+            "{{#each commits}}",
+            "{{> commit root=@root}}",
+            "{{/each}}",
+            "",
+            "{{/each}}{{#if noteGroups.length}}---",
+            "",
+            "{{#each noteGroups}}### {{title}}",
+            "",
+            "{{#each notes}}",
+            "* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}",
+            "{{/each}}",
+            "",
+            "{{/each}}{{/if}}{{#if previousTag}}**Full Changelog**: {{@root.host}}/{{@root.owner}}/{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}",
+            "{{/if}}",
+          ].join("\n"),
+        },
       },
     ],
     [
@@ -76,7 +105,7 @@ module.exports = {
     [
       "@semantic-release/git",
       {
-        assets: ["package.json", "package-lock.json", "CHANGELOG.md", "README.md", "system.json"],
+        assets: ["package.json", "package-lock.json", "README.md", "system.json"],
         message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },
     ],

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
     "@foundryvtt/foundryvtt-cli": "^1.0.3",
-    "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.2",


### PR DESCRIPTION
- Drop the `@semantic-release/changelog` plugin and remove `CHANGELOG.md` from `@semantic-release/git` assets — release notes now live only on the Releases page.
- Align the automated release notes with the preferred style
