### PR TITLE
fix(chat): exclude dice roll lists from global editor list styles (#175)

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -451,41 +451,41 @@ a.inline-roll:hover > i {
   padding: 8px;
 }
 
-.editor-content ul,
-.editor-content ol,
-.chat-message .message-content ul,
-.chat-message .message-content ol,
-.chat-message .message-content .prosemirror-content ul,
-.chat-message .message-content .prosemirror-content ol {
+.editor-content ul:not(.dice-rolls),
+.editor-content ol:not(.dice-rolls),
+.chat-message .message-content ul:not(.dice-rolls),
+.chat-message .message-content ol:not(.dice-rolls),
+.chat-message .message-content .prosemirror-content ul:not(.dice-rolls),
+.chat-message .message-content .prosemirror-content ol:not(.dice-rolls) {
   margin: 8px 0;
   padding-left: 24px;
 }
-.editor-content ul li,
-.editor-content ol li,
-.chat-message .message-content ul li,
-.chat-message .message-content ol li,
-.chat-message .message-content .prosemirror-content ul li,
-.chat-message .message-content .prosemirror-content ol li {
+.editor-content ul:not(.dice-rolls) li,
+.editor-content ol:not(.dice-rolls) li,
+.chat-message .message-content ul:not(.dice-rolls) li,
+.chat-message .message-content ol:not(.dice-rolls) li,
+.chat-message .message-content .prosemirror-content ul:not(.dice-rolls) li,
+.chat-message .message-content .prosemirror-content ol:not(.dice-rolls) li {
   margin-bottom: 4px;
 }
-.editor-content ul,
-.chat-message .message-content ul,
-.chat-message .message-content .prosemirror-content ul {
+.editor-content ul:not(.dice-rolls),
+.chat-message .message-content ul:not(.dice-rolls),
+.chat-message .message-content .prosemirror-content ul:not(.dice-rolls) {
   list-style-type: disc;
 }
-.editor-content ul ul,
-.chat-message .message-content ul ul,
-.chat-message .message-content .prosemirror-content ul ul {
+.editor-content ul:not(.dice-rolls) ul:not(.dice-rolls),
+.chat-message .message-content ul:not(.dice-rolls) ul:not(.dice-rolls),
+.chat-message .message-content .prosemirror-content ul:not(.dice-rolls) ul:not(.dice-rolls) {
   list-style-type: circle;
 }
-.editor-content ul ul ul,
-.chat-message .message-content ul ul ul,
-.chat-message .message-content .prosemirror-content ul ul ul {
+.editor-content ul:not(.dice-rolls) ul:not(.dice-rolls) ul:not(.dice-rolls),
+.chat-message .message-content ul:not(.dice-rolls) ul:not(.dice-rolls) ul:not(.dice-rolls),
+.chat-message .message-content .prosemirror-content ul:not(.dice-rolls) ul:not(.dice-rolls) ul:not(.dice-rolls) {
   list-style-type: square;
 }
-.editor-content ol,
-.chat-message .message-content ol,
-.chat-message .message-content .prosemirror-content ol {
+.editor-content ol:not(.dice-rolls),
+.chat-message .message-content ol:not(.dice-rolls),
+.chat-message .message-content .prosemirror-content ol:not(.dice-rolls) {
   list-style-type: decimal;
 }
 .editor-content hr,

--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -508,8 +508,8 @@ a.inline-roll {
 .chat-message .message-content,
 .chat-message .message-content .prosemirror-content {
   // Ensure proper list styling
-  ul,
-  ol {
+  ul:not(.dice-rolls),
+  ol:not(.dice-rolls) {
     margin: 8px 0;
     padding-left: 24px;
 
@@ -518,19 +518,19 @@ a.inline-roll {
     }
   }
 
-  ul {
+  ul:not(.dice-rolls) {
     list-style-type: disc;
 
-    ul {
+    ul:not(.dice-rolls) {
       list-style-type: circle;
 
-      ul {
+      ul:not(.dice-rolls) {
         list-style-type: square;
       }
     }
   }
 
-  ol {
+  ol:not(.dice-rolls) {
     list-style-type: decimal;
   }
 


### PR DESCRIPTION
Before:
<img width="296" height="230" alt="image" src="https://github.com/user-attachments/assets/2ed664e7-fa1b-43d5-9f02-29a4f3f2ad9d" />


After:
<img width="294" height="220" alt="image" src="https://github.com/user-attachments/assets/7fbfa525-ea60-4888-aabd-94f50d6e12f8" />
